### PR TITLE
Update to work with Elasticsearch v0.90.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.19.0</elasticsearch.version>
+        <elasticsearch.version>0.90.3</elasticsearch.version>
     </properties>
 
     <repositories>
@@ -76,6 +76,15 @@
             <version>1.3.RC2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.8.1</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -14,5 +14,13 @@
                 <exclude>org.elasticsearch:elasticsearch</exclude>
             </excludes>
         </dependencySet>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>org.apache.ant:ant</include>
+            </includes>
+        </dependencySet>
     </dependencySets>
 </assembly>

--- a/src/main/java/org/elasticsearch/river/wikipedia/support/WikiXMLParser.java
+++ b/src/main/java/org/elasticsearch/river/wikipedia/support/WikiXMLParser.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.river.wikipedia.support;
 
-import org.elasticsearch.common.compress.bzip2.CBZip2InputStream;
+import org.apache.tools.bzip2.CBZip2InputStream;
 import org.xml.sax.InputSource;
 
 import java.io.BufferedReader;


### PR DESCRIPTION
CBZip2InputStream is no longer in org.elasticsearch.common.compress.
